### PR TITLE
Remove multi space

### DIFF
--- a/prepress.py
+++ b/prepress.py
@@ -486,6 +486,17 @@ def remove_extraneous_spaces(article: Article) -> Article:
         text_tag.replace_with(new_tag)
     return article
 
+def remove_multi_spaces(article: Article) -> Article:
+    """Removes double, triple, etc., spaces.
+    """
+    text_tag: bs4.NavigableString
+    for text_tag in article.content.find_all(string=True):
+        if keep_verbatim(text_tag): continue
+
+        new_tag = re.sub(r'([^\s])(\s)+([^\s])', '\1 \3', text_tag)
+        text_tag.replace_with(new_tag)
+    return article
+
 def normalize_newlines(article: Article) -> Article:
     """Normalizes newlines to Unix-style LF
     """
@@ -566,6 +577,7 @@ POST_PROCESS: List[Callable[[Article], Article]] = [
     replace_dashes,
     add_smart_quotes,
     remove_extraneous_spaces,
+    remove_multi_spaces,
     add_footnotes
 ]
 

--- a/prepress.py
+++ b/prepress.py
@@ -488,13 +488,24 @@ def remove_extraneous_spaces(article: Article) -> Article:
         punctuation = string.punctuation + '‽'
 
         single_spaced_chars = base_alphanumeric + accent_characters + punctuation
-        multispaces = r'(?<=[{}]) +'.format(single_spaced_chars)
 
-        new_tag = re.sub(multispaces, ' ', text_tag)
+        # a number of articles come to us with punctuation followed by a double space, where the 
+        #  first space is an nbsp. maybe it is inserted by a particular text editor?
+        #  if we remove them directly, we can stop worrying about nbsps from that point on
+        #  (who would be unintentionally adding consecutive nbsps)
+        nbsp_sp_pairs = r'(?<=[{}])(\u00A0 )+'.format(single_spaced_chars)
+        new_tag = re.sub(nbsp_sp_pairs, ' ', text_tag)
+
+        nbsp_sps_found = new_tag != text_tag 
+
+        # with the nbsp-sp pairs removed, we can remove all other n-tuple breaking spaces
+        multi_sp = r'(?<=[{}]) +'.format(single_spaced_chars)
+        new_tag = re.sub(multi_sp, ' ', new_tag)
+
         text_tag.replace_with(new_tag)
 
-        if(new_tag != text_tag):
-            print("Removed extraneous spaces in article \"" + article.title + "\"")
+        if(nbsp_sps_found or new_tag != text_tag):
+            print("Removed extraneous spaces in article \"" + article.title + "\"" + (". Some were nbsp-sp pairs." if nbsp_sps_found else ""))
     return article
 
 def normalize_newlines(article: Article) -> Article:

--- a/prepress.py
+++ b/prepress.py
@@ -476,24 +476,13 @@ def add_smart_quotes(article: Article) -> Article:
     return article
 
 def remove_extraneous_spaces(article: Article) -> Article:
-    """Removes extraneous spaces after punctuation.
+    """Removes extraneous spaces after characters.
     """
     text_tag: bs4.NavigableString
     for text_tag in article.content.find_all(string=True):
         if keep_verbatim(text_tag): continue
 
-        new_tag = re.sub(r'(?<=[.,;?!‽]) +', ' ', text_tag)
-        text_tag.replace_with(new_tag)
-    return article
-
-def remove_multi_spaces(article: Article) -> Article:
-    """Removes double, triple, etc., spaces.
-    """
-    text_tag: bs4.NavigableString
-    for text_tag in article.content.find_all(string=True):
-        if keep_verbatim(text_tag): continue
-
-        new_tag = re.sub(r'([^\s])(\s)+([^\s])', '\1 \3', text_tag)
+        new_tag = re.sub(r'(?<=[A-Za-z0-9$.,;?!‽]) +', ' ', text_tag)
         text_tag.replace_with(new_tag)
     return article
 
@@ -577,7 +566,6 @@ POST_PROCESS: List[Callable[[Article], Article]] = [
     replace_dashes,
     add_smart_quotes,
     remove_extraneous_spaces,
-    remove_multi_spaces,
     add_footnotes
 ]
 


### PR DESCRIPTION
**Why**

We accidentally let a double space slip through last issue. 

**What**

Updates the `remove_extraneous_spaces` processor, which currently replaces all double, triple, n-tuple spaces after punctuation with single spaces.

Instead of only doing so after punctuation, this now lets it catch (n>1)-tuple spaces after any normal text character - that being alphanumerics, accent characters (like é), and punctuation. This will catch more double spaces between words.

**Testing**

In v156i1, we had this double space make it through. It was an instance of the nbsp-sp pair.

![image](https://github.com/user-attachments/assets/911f11a8-fa7d-4c9c-9950-b0d5ee8c14b5)

![image](https://github.com/user-attachments/assets/cdaf01e3-49b9-4b65-83d4-08e5bddba2c3)

It is caught by this new processor, as are some intentional double spaces I added to "N WUSA excerpts" and "the land called Gespe'g"